### PR TITLE
sort helpers for map[string]string

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -256,3 +256,21 @@ func TestStringMapByValue(t *testing.T) {
 		t.Fatal()
 	}
 }
+
+func TestStringMapByKey(t *testing.T) {
+	r := map[string]string{
+		"baz": "zoo",
+		"foo": "bar",
+	}
+	s := StringMapByKey(r)
+	if len(s) != 2 {
+		t.Fatal("expected 2 pairs")
+	}
+	first, second := s[0], s[1]
+	if first.Key != "baz" || first.Value != "zoo" || second.Key != "foo" || second.Value != "bar" {
+		t.Fatal()
+	}
+	if !sort.IsSorted(s) {
+		t.Fatal()
+	}
+}

--- a/sortutil.go
+++ b/sortutil.go
@@ -193,21 +193,40 @@ type StringPair struct {
 	Value string
 }
 
-// A map of Pairs that implements sort.Interface to sort by Value.
-type StringPairMap []StringPair
-
-func (p StringPairMap) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p StringPairMap) Len() int           { return len(p) }
-func (p StringPairMap) Less(i, j int) bool { return p[i].Value < p[j].Value }
-
-// A function to turn a map into a StringPairMap, then sort and return it.
-func StringMapByValue(m map[string]string) StringPairMap {
-	p := make(StringPairMap, len(m))
+func mapStringPair(m map[string]string) []StringPair {
+	p := make([]StringPair, len(m))
 	i := 0
 	for k, v := range m {
 		p[i] = StringPair{k, v}
 		i++
 	}
+	return p
+}
+
+// A map of Pairs that implements sort.Interface to sort by Value.
+type StringPairByValueMap []StringPair
+
+func (p StringPairByValueMap) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p StringPairByValueMap) Len() int           { return len(p) }
+func (p StringPairByValueMap) Less(i, j int) bool { return p[i].Value < p[j].Value }
+
+// A function to turn a map into a StringPairByValueMap, then sort and return it.
+func StringMapByValue(m map[string]string) StringPairByValueMap {
+	p := StringPairByValueMap(mapStringPair(m))
+	sort.Sort(p)
+	return p
+}
+
+// A map of Pairs that implements sort.Interface to sort by Key.
+type StringPairByKeyMap []StringPair
+
+func (p StringPairByKeyMap) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p StringPairByKeyMap) Len() int           { return len(p) }
+func (p StringPairByKeyMap) Less(i, j int) bool { return p[i].Key < p[j].Key }
+
+// A function to turn a map into a StringPairByKeyMap, then sort and return it.
+func StringMapByKey(m map[string]string) StringPairByKeyMap {
+	p := StringPairByKeyMap(mapStringPair(m))
 	sort.Sort(p)
 	return p
 }


### PR DESCRIPTION
Adds sort by key/value support for map[string]string.
